### PR TITLE
Fix sendLog request callback

### DIFF
--- a/src/sumoLogger.js
+++ b/src/sumoLogger.js
@@ -56,17 +56,17 @@ function sendLogs() {
     }, function (error, response) {
       var err = !!error || response.status < 200 || response.status >= 400;
 
-      if (err && currentConfig.hasOwnProperty('onError')) {
+      if (err && currentConfig.onError && typeof currentConfig.onError === 'function') {
         currentConfig.onError();
       } else {
-        if (currentConfig.hasOwnProperty('onSuccess')) {
+        if (currentConfig.onSuccess && typeof currentConfig.onSuccess === 'function') {
           currentConfig.onSuccess();
         }
         currentLogs = [];
       }
     });
   } catch (ex) {
-    if (currentConfig.hasOwnProperty('onError')) {
+    if (currentConfig.onError && typeof currentConfig.onError === 'function') {
       currentConfig.onError();
     }
   }

--- a/src/sumoLogger.js
+++ b/src/sumoLogger.js
@@ -35,6 +35,8 @@ function sendLogs() {
     return;
   }
   var tempCategory = '';
+  var logsToSend = currentLogs;
+  currentLogs = [];
 
   try {
     var headers = {'Content-Type': 'application/json'};
@@ -52,23 +54,26 @@ function sendLogs() {
       method: 'POST',
       url: currentConfig.endpoint,
       headers: headers,
-      body: currentLogs.concat('\n')
+      body: logsToSend.concat('\n')
     }, function (error, response) {
       var err = !!error || response.status < 200 || response.status >= 400;
 
-      if (err && currentConfig.onError && typeof currentConfig.onError === 'function') {
-        currentConfig.onError();
+      if (err) {
+        if(currentConfig.onError && typeof currentConfig.onError === 'function') {
+          currentConfig.onError();
+        }
+        currentLogs.concat(logsToSend);
       } else {
         if (currentConfig.onSuccess && typeof currentConfig.onSuccess === 'function') {
           currentConfig.onSuccess();
         }
-        currentLogs = [];
       }
     });
   } catch (ex) {
     if (currentConfig.onError && typeof currentConfig.onError === 'function') {
       currentConfig.onError();
     }
+    currentLogs.concat(logsToSend);
   }
 }
 


### PR DESCRIPTION
Since currentConfig's `onSuccess` and `onError` properties default to `false` if no function is provided the callback properties were always being executed as functions. This was causing an error and prevented the `currentLogs` array from being cleared which resulted in duplicate logs.

With a short enough interval and frequent enough log messages the same messages may be sent multiple times before the currentLogs array is cleared by successfully sending logs. I adjusted the code to move the messages to a new array and clear `currentLogs`. If an error occurs the messages are returned to `currentLogs`.