### PR TITLE
Moved from Request to Axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "axios": "^0.18.0",
-    "underscore": "^1.8.3"
+    "lodash.assignin": "^4.2.0",
+    "lodash.isempty": "^4.4.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",
@@ -26,7 +27,7 @@
     "grunt-contrib-jasmine": "^1.1.0",
     "grunt-contrib-uglify": "^3.3.0",
     "grunt-http-server": "^2.1.0",
-    "mocha": "^5.0.1",
+    "mocha": "^5.0.4",
     "np": "^2.13.1",
     "nyc": "^11.4.1",
     "proxyquire": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:browser": "npm run http-server && open https://127.0.0.1:8282/jasminetest/TrackerSpecRunner.html"
   },
   "dependencies": {
-    "request": "^2.83.0",
+    "axios": "^0.18.0",
     "underscore": "^1.8.3"
   },
   "devDependencies": {

--- a/src/sumoLogger.js
+++ b/src/sumoLogger.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const axios = require('axios');
-const _ = require('underscore');
+const isEmpty = require('lodash.isempty');
+const assignIn = require('lodash.assignin');
 
 const DEFAULT_INTERVAL = 0;
 const NOOP = () => {};
@@ -46,18 +47,18 @@ function sendLogs() {
     try {
         const headers = {};
         if (currentConfig.graphite) {
-            _.extend(headers, { 'Content-Type': 'application/vnd.sumologic.graphite' });
+            assignIn(headers, { 'Content-Type': 'application/vnd.sumologic.graphite' });
         } else {
-            _.extend(headers, { 'Content-Type': 'application/json' });
+            assignIn(headers, { 'Content-Type': 'application/json' });
         }
         if (currentConfig.sourceName !== '') {
-            _.extend(headers, { 'X-Sumo-Name': currentConfig.sourceName });
+            assignIn(headers, { 'X-Sumo-Name': currentConfig.sourceName });
         }
         if (currentConfig.sourceCategory !== '') {
-            _.extend(headers, { 'X-Sumo-Category': currentConfig.sourceCategory });
+            assignIn(headers, { 'X-Sumo-Category': currentConfig.sourceCategory });
         }
         if (currentConfig.hostName !== '') {
-            _.extend(headers, { 'X-Sumo-Host': currentConfig.hostName });
+            assignIn(headers, { 'X-Sumo-Host': currentConfig.hostName });
         }
 
         logsToSend = currentLogs;
@@ -92,7 +93,7 @@ function SumoLogger(opts) {
 
 SumoLogger.prototype.updateConfig = (newOpts) => {
     try {
-        if (!_.isEmpty(newOpts)) {
+        if (!isEmpty(newOpts)) {
             if (newOpts.endpoint) {
                 currentConfig.endpoint = newOpts.endpoint;
             }
@@ -185,7 +186,7 @@ SumoLogger.prototype.log = (msg, optionalConfig) => {
             return `${item.path} ${item.value} ${Math.round(ts.getTime() / 1000)}`;
         }
         if (typeof item === 'string') {
-            return JSON.stringify(_.extend({
+            return JSON.stringify(assignIn({
                 msg: item,
                 sessionId: sessKey,
                 timestamp
@@ -195,7 +196,7 @@ SumoLogger.prototype.log = (msg, optionalConfig) => {
             sessionId: sessKey,
             timestamp
         };
-        return JSON.stringify(_.extend(current, client, item));
+        return JSON.stringify(assignIn(current, client, item));
     });
 
     currentLogs = currentLogs.concat(messages);

--- a/src/sumoLogger.js
+++ b/src/sumoLogger.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const request = require('request');
+const axios = require('axios');
 const _ = require('underscore');
 
 const DEFAULT_INTERVAL = 0;
@@ -63,24 +63,20 @@ function sendLogs() {
         logsToSend = currentLogs;
         currentLogs = [];
 
-        request({
-            method: 'POST',
-            url: currentConfig.endpoint,
-            headers,
-            body: logsToSend.join('\n')
-        }, (error, response) => {
-            const err = !!error || response.statusCode < 200 || response.statusCode >= 400;
-
-            if (err) {
-                currentLogs = logsToSend;
-                currentConfig.onError();
-            } else {
-                currentConfig.onSuccess();
-            }
+        axios.post(
+            currentConfig.endpoint,
+            logsToSend.join('\n'),
+            { headers }
+        ).then(() => {
+            logsToSend = [];
+            currentConfig.onSuccess();
+        }).catch((error) => {
+            currentConfig.onError(error.message);
+            currentLogs = logsToSend;
         });
     } catch (ex) {
         currentLogs = logsToSend;
-        currentConfig.onError();
+        currentConfig.onError(ex.message);
     }
 }
 

--- a/test/sumoLogger.test.js
+++ b/test/sumoLogger.test.js
@@ -1,32 +1,28 @@
-const proxyquire = require('proxyquire');
+const underscore = require('underscore');
+const axios = require('axios');
 
-const requestStub = sinon.stub();
+const SumoLogger = require('../src/sumoLogger');
+
 const onSuccessSpy = sinon.spy();
 const onErrorSpy = sinon.spy();
-const isEmptyStub = sinon.stub();
 
 const endpoint = 'endpoint';
 const message = 'message';
 const timestamp = new Date();
 const sessionKey = 'abcd1234';
 
-const SumoLogger = proxyquire('../src/sumoLogger', {
-    request: requestStub,
-    underscore: {
-        isEmpty: isEmptyStub
-    }
-});
+const sandbox = sinon.sandbox.create();
 
 describe('sumoLogger', () => {
     beforeEach(() => {
-        sinon.stub(console, 'error');
+        sandbox.stub(axios, 'post');
+        sandbox.spy(console, 'error');
     });
 
     afterEach(() => {
-        requestStub.reset();
         onSuccessSpy.resetHistory();
         onErrorSpy.resetHistory();
-        console.error.restore();
+        sandbox.restore();
     });
 
     describe('log()', () => {
@@ -45,14 +41,15 @@ describe('sumoLogger', () => {
                 sessionKey
             });
 
-            expect(requestStub).to.have.been.calledWithMatch({
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                method: 'POST',
-                url: 'endpoint',
-                body
-            });
+            expect(axios.post).to.have.been.calledWithExactly(
+                endpoint,
+                body,
+                {
+                    headers: {
+                        'Content-Type': 'application/json'
+                    }
+                }
+            );
         });
 
         it('should send a message object', () => {
@@ -71,14 +68,15 @@ describe('sumoLogger', () => {
                 key: 'value'
             });
 
-            expect(requestStub).to.have.been.calledWithMatch({
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                method: 'POST',
-                url: 'endpoint',
-                body
-            });
+            expect(axios.post).to.have.been.calledWithMatch(
+                endpoint,
+                body,
+                {
+                    headers: {
+                        'Content-Type': 'application/json'
+                    }
+                }
+            );
         });
 
         it('should send a message array', () => {
@@ -96,14 +94,15 @@ describe('sumoLogger', () => {
                 sessionKey
             });
 
-            expect(requestStub).to.have.been.calledWithMatch({
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                method: 'POST',
-                url: 'endpoint',
-                body
-            });
+            expect(axios.post).to.have.been.calledWithMatch(
+                endpoint,
+                body,
+                {
+                    headers: {
+                        'Content-Type': 'application/json'
+                    }
+                }
+            );
         });
 
         it('should extend headers if they exist in the config', () => {
@@ -118,16 +117,30 @@ describe('sumoLogger', () => {
                 hostName
             });
 
-            logger.log(message);
-
-            expect(requestStub).to.have.been.calledWithMatch({
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-Sumo-Name': sourceName,
-                    'X-Sumo-Category': sourceCategory,
-                    'X-Sumo-Host': hostName
-                }
+            const body = JSON.stringify({
+                msg: message,
+                sessionId: sessionKey,
+                timestamp: timestamp.toUTCString(),
+                url: ''
             });
+
+            logger.log(message, {
+                timestamp,
+                sessionKey
+            });
+
+            expect(axios.post).to.have.been.calledWithMatch(
+                endpoint,
+                body,
+                {
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-Sumo-Name': sourceName,
+                        'X-Sumo-Category': sourceCategory,
+                        'X-Sumo-Host': hostName
+                    }
+                }
+            );
         });
 
         it('should set the graphite header if graphite enabled', () => {
@@ -136,16 +149,26 @@ describe('sumoLogger', () => {
                 graphite: true
             });
 
-            logger.log({
-                path: 'graphite.metric.path',
-                value: 100
-            });
-
-            expect(requestStub).to.have.been.calledWithMatch({
-                headers: {
-                    'Content-Type': 'application/vnd.sumologic.graphite'
+            logger.log(
+                {
+                    path: 'graphite.metric.path',
+                    value: 100
+                },
+                {
+                    timestamp,
+                    sessionKey
                 }
-            });
+            );
+
+            expect(axios.post).to.have.been.calledWithMatch(
+                endpoint,
+                `graphite.metric.path 100 ${Math.round(timestamp.getTime() / 1000)}`,
+                {
+                    headers: {
+                        'Content-Type': 'application/vnd.sumologic.graphite'
+                    }
+                }
+            );
         });
 
         it('should send correctly formated graphite metrics if graphite enabled', () => {
@@ -160,9 +183,10 @@ describe('sumoLogger', () => {
                 value: 100
             }, { timestamp });
 
-            expect(requestStub).to.have.been.calledWithMatch({
-                body: `graphite.metric.path 100 ${expectedTimestamp}`
-            });
+            expect(axios.post).to.have.been.calledWithMatch(
+                endpoint,
+                `graphite.metric.path 100 ${expectedTimestamp}`
+            );
         });
 
         it('should send correctly formatted graphite metrics in batch', () => {
@@ -188,30 +212,14 @@ describe('sumoLogger', () => {
                 }
             );
 
-            expect(requestStub).to.have.been.calledWithMatch({
-                body: `graphite.metric.path 100 ${expectedTimestamp}\nanother.graphite.metric.path 50 ${expectedTimestamp}`
-            });
-        });
-
-        it('should not send request straight away if interval set', (done) => {
-            const logger = new SumoLogger({
+            expect(axios.post).to.have.been.calledWithMatch(
                 endpoint,
-                interval: 10
-            });
-
-            logger.log(message);
-
-            expect(requestStub).to.not.have.been.called;
-
-            setTimeout(() => {
-                logger.stopLogSending();
-                expect(requestStub).to.have.been.calledOnce;
-                done();
-            }, 20);
+                `graphite.metric.path 100 ${expectedTimestamp}\nanother.graphite.metric.path 50 ${expectedTimestamp}`
+            );
         });
 
-        it('should call the onSuccess callback if the request succeeds', () => {
-            requestStub.yields(null, { statusCode: 200 });
+        it('should call the onSuccess callback if the request succeeds', (done) => {
+            axios.post.resolves({ status: 200 });
 
             const logger = new SumoLogger({
                 endpoint,
@@ -220,11 +228,14 @@ describe('sumoLogger', () => {
 
             logger.log(message);
 
-            expect(onSuccessSpy).to.have.been.calledOnce;
+            setTimeout(() => {
+                expect(onSuccessSpy).to.have.been.calledOnce;
+                done();
+            }, 10);
         });
 
-        it('should call the onError callback if an error object is returned', () => {
-            requestStub.yields(new Error('unavailable'), {});
+        it('should call the onError callback if an error object is returned', (done) => {
+            axios.post.rejects(new Error('unavailable'));
 
             const logger = new SumoLogger({
                 endpoint,
@@ -233,33 +244,10 @@ describe('sumoLogger', () => {
 
             logger.log(message);
 
-            expect(onErrorSpy).to.have.been.calledOnce;
-        });
-
-        it('should call the onError callback if the statusCode is less than 200', () => {
-            requestStub.yields(null, { statusCode: 100 });
-
-            const logger = new SumoLogger({
-                endpoint,
-                onError: onErrorSpy
-            });
-
-            logger.log(message);
-
-            expect(onErrorSpy).to.have.been.calledOnce;
-        });
-
-        it('should call the onError callback if the statusCode is greater than 400', () => {
-            requestStub.yields(null, { statusCode: 404 });
-
-            const logger = new SumoLogger({
-                endpoint,
-                onError: onErrorSpy
-            });
-
-            logger.log(message);
-
-            expect(onErrorSpy).to.have.been.calledOnce;
+            setTimeout(() => {
+                expect(onErrorSpy).to.have.been.calledWith('unavailable');
+                done();
+            }, 10);
         });
     });
 
@@ -267,22 +255,35 @@ describe('sumoLogger', () => {
         it('should update the instance config with the new values', (done) => {
             const logger = new SumoLogger({ endpoint });
 
+            const body = JSON.stringify({
+                msg: message,
+                sessionId: sessionKey,
+                timestamp: timestamp.toUTCString(),
+                url: ''
+            });
+
             logger.updateConfig({
                 endpoint: 'newendpoint',
                 sourceCategory: 'newSourceCategory',
                 interval: 10
             });
 
-            logger.log(message);
+            logger.log(message, {
+                timestamp,
+                sessionKey
+            });
 
             setTimeout(() => {
-                expect(requestStub).to.have.been.calledWithMatch({
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-Sumo-Category': 'newSourceCategory'
-                    },
-                    url: 'newendpoint'
-                });
+                expect(axios.post).to.have.been.calledWithMatch(
+                    'newendpoint',
+                    body,
+                    {
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-Sumo-Category': 'newSourceCategory'
+                        }
+                    }
+                );
                 logger.stopLogSending();
                 done();
             }, 20);
@@ -291,34 +292,57 @@ describe('sumoLogger', () => {
         it('should not update config if allowed values are not provided', () => {
             const logger = new SumoLogger({ endpoint });
 
+            const body = JSON.stringify({
+                msg: message,
+                sessionId: sessionKey,
+                timestamp: timestamp.toUTCString(),
+                url: ''
+            });
+
             logger.updateConfig({
                 randomProperty: 'randomValue'
             });
 
             logger.log(message);
 
-            expect(requestStub).to.have.been.calledWithMatch({
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                url: 'endpoint'
-            });
+            expect(axios.post).to.have.been.calledWithMatch(
+                endpoint,
+                body,
+                {
+                    headers: {
+                        'Content-Type': 'application/json'
+                    }
+                }
+            );
         });
 
         it('should not update config if no values are not provided', () => {
-            isEmptyStub.returns(true);
+            sandbox.stub(underscore, 'isEmpty').returns(true);
             const logger = new SumoLogger({ endpoint });
+
+            const body = JSON.stringify({
+                msg: message,
+                sessionId: sessionKey,
+                timestamp: timestamp.toUTCString(),
+                url: ''
+            });
 
             logger.updateConfig({});
 
-            logger.log(message);
-
-            expect(requestStub).to.have.been.calledWithMatch({
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                url: 'endpoint'
+            logger.log(message, {
+                timestamp,
+                sessionKey
             });
+
+            expect(axios.post).to.have.been.calledWithMatch(
+                endpoint,
+                body,
+                {
+                    headers: {
+                        'Content-Type': 'application/json'
+                    }
+                }
+            );
         });
     });
 
@@ -329,13 +353,16 @@ describe('sumoLogger', () => {
                 interval: 10
             });
 
-            logger.log(message);
+            logger.log(message, {
+                timestamp,
+                sessionKey
+            });
 
             logger.emptyLogQueue();
 
             setTimeout(() => {
                 logger.stopLogSending();
-                expect(requestStub).to.not.have.been.called;
+                expect(axios.post).to.not.have.been.called;
                 done();
             }, 20);
         });
@@ -350,11 +377,11 @@ describe('sumoLogger', () => {
 
             logger.log(message);
 
-            expect(requestStub).to.not.have.been.called;
+            expect(axios.post).to.not.have.been.called;
 
             logger.flushLogs();
 
-            expect(requestStub).to.have.been.calledOnce;
+            expect(axios.post).to.have.been.calledOnce;
 
             logger.stopLogSending();
         });
@@ -414,21 +441,8 @@ describe('sumoLogger', () => {
             expect(console.error).to.have.been.calledWith('Sumo Logic requires both \'path\' and \'value\' properties to be provided in the message object');
         });
 
-        it('catch error sending request', () => {
-            requestStub.throws(new Error(message));
-
-            const logger = new SumoLogger({
-                endpoint,
-                onError: onErrorSpy
-            });
-
-            logger.log(message);
-
-            expect(onErrorSpy).to.have.been.calledOnce;
-        });
-
         it('error updating config', () => {
-            isEmptyStub.throws(new Error(message));
+            sandbox.stub(underscore, 'isEmpty').throws(new Error(message));
 
             const logger = new SumoLogger({ endpoint });
 

--- a/test/sumoLogger.test.js
+++ b/test/sumoLogger.test.js
@@ -1,8 +1,7 @@
-const underscore = require('underscore');
+const proxyquire = require('proxyquire');
 const axios = require('axios');
 
-const SumoLogger = require('../src/sumoLogger');
-
+const isEmptyStub = sinon.stub();
 const onSuccessSpy = sinon.spy();
 const onErrorSpy = sinon.spy();
 
@@ -10,6 +9,10 @@ const endpoint = 'endpoint';
 const message = 'message';
 const timestamp = new Date();
 const sessionKey = 'abcd1234';
+
+const SumoLogger = proxyquire('../src/sumoLogger', {
+    'lodash.isempty': isEmptyStub
+});
 
 const sandbox = sinon.sandbox.create();
 
@@ -20,6 +23,7 @@ describe('sumoLogger', () => {
     });
 
     afterEach(() => {
+        isEmptyStub.reset();
         onSuccessSpy.resetHistory();
         onErrorSpy.resetHistory();
         sandbox.restore();
@@ -317,7 +321,7 @@ describe('sumoLogger', () => {
         });
 
         it('should not update config if no values are not provided', () => {
-            sandbox.stub(underscore, 'isEmpty').returns(true);
+            isEmptyStub.returns(true);
             const logger = new SumoLogger({ endpoint });
 
             const body = JSON.stringify({
@@ -442,7 +446,7 @@ describe('sumoLogger', () => {
         });
 
         it('error updating config', () => {
-            sandbox.stub(underscore, 'isEmpty').throws(new Error(message));
+            isEmptyStub.throws(new Error(message));
 
             const logger = new SumoLogger({ endpoint });
 


### PR DESCRIPTION
@billsaysthis this enables the sumoLogger.js file to work both in Node and bundled for a web application too so a big step!  Hopefully after this there shouldn't really be a need for the web-only library.

I've tested this in our implementation of Sumo Logic and both metrics and logs are sent exactly the same way as when the request library was used so should be a seamless change.

Also, by swapping packages the bundled size is down from 314kb to less than  8kb :)