### PR TITLE
Add "browser" property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.0",
   "description": "Sumo Logic Javascript SDK for sending logs to a HTTP Source endpoint.",
   "main": "lib/sumoLogger.js",
+  "browser": "lib/sumologic.logger.min.js",
   "scripts": {
     "release": "np",
     "http-server": "grunt http-server:dev &",


### PR DESCRIPTION
The "browser" property in the package.json will instruct bundlers like Webpack to use the browser build instead of the node.js build.  If the browser field is missing, it will use "main".

A bug in the Axios library causes unexpected behavior in projects which use Axios for other purposes, because any headers which are configured as defaults are shared by all instances.  

See https://github.com/axios/axios/issues/385

This resolves the issue reported here

https://github.com/SumoLogic/js-logging-sdk/issues/28

